### PR TITLE
fix: close socket after reading data

### DIFF
--- a/src/libs/minecraft.ts
+++ b/src/libs/minecraft.ts
@@ -127,6 +127,7 @@ const helpers = {
 				}
 				result += decoder.decode(value);
 			}
+			socket.close();
 			const parsed = parseResponse(result);
 
 			if (parsed.statusCode === 429) {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,7 @@
 name = "playerdb-dev"
 account_id = "59a6a7816e5ccdd2ef4dc158bcd8b014"
 workers_dev = true
-compatibility_date = "2025-01-19"
+compatibility_date = "2025-08-16"
 compatibility_flags = [
 	"nodejs_compat",
 	"no_nodejs_compat_v2"
@@ -58,3 +58,4 @@ minify = true
 [env.production.observability]
 enabled = true
 head_sampling_rate = 1
+traces = {enabled = true}


### PR DESCRIPTION
This wasn't causing issues today, but resulted in trace spans looking a little wonky with the `connect` staying open. We should definitely close these gracefully anyway.