### PR TITLE
fix(xbox): map GameDisplayPicRaw to avatar property

### DIFF
--- a/src/libs/xbox.ts
+++ b/src/libs/xbox.ts
@@ -122,16 +122,19 @@ const helpers = {
 			player.username = player.meta.realName;
 		}
 
-		// set avatar
-		player.avatar = `https://avatar-ssl.xboxlive.com/avatar/${player.username}/avatarpic-l.png`;
+		// ensure an avatar is defined
+		if (!player.avatar) {
+			player.avatar = `https://avatar-ssl.xboxlive.com/avatar/${player.username}/avatarpic-l.png`;
+		}
 
 		return player;
 	},
 	map: {
 		Gamertag: 'username',
+		GameDisplayPicRaw: 'avatar',
 	},
 	// Skip fields we don't need to process
-	skipFields: new Set(['GameDisplayPicRaw']),
+	skipFields: new Set<string>([]),
 };
 
 async function getProfile(


### PR DESCRIPTION
While querying your service I noticed that invalid urls are returned for avatars on xbox (`https://avatar-ssl.xboxlive.com/avatar/derklaro7460/avatarpic-l.png`). These URLs no longer work (I think since last year, but I'm not 100% sure). The upstream api returns a `GameDisplayPicRaw` setting which maps to the (now) correct avatar url, e.g. `https://images-eds-ssl.xboxlive.com/image?url=z951ykn43p4FqWbbFvR2Ec.8vbDhj8G2Xe7JngaTToBrrCmIEEXHC9UNrdJ6P7KInFWvSpSRjZdv2hLMF4c4dWx9V77fRY6D1Kw_b_XFZA34J0ywf42o98Nt2Tc.gBLS&format=png`. I went ahead and mapped the GameDisplayPicRaw setting to the avatar field, and only used the old url style as a fallback.