### PR TITLE
fix: have the web font swap in

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,6 +15,11 @@
 		<link href="https://analytics.nodecraft.com" rel="preconnect" crossorigin />
 		<link href="https://fonts.googleapis.com" rel="preconnect" crossorigin />
 		<link href="https://fonts.gstatic.com" rel="preconnect" crossorigin />
+		<link
+			href="https://fonts.googleapis.com/css?family=Open+Sans:400,700&display=swap"
+			rel="stylesheet"
+			type="text/css"
+		/>
 		<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
 		<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
 		<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
@@ -108,7 +113,6 @@
 			background: #493e6b;
 			color: #fff;
 			font-family: 'Open Sans', sans-serif;
-			font-weight: lighter;
 			margin: 0;
 		"
 	>
@@ -120,7 +124,7 @@
 				height="130"
 				width="585"
 			/>
-			<h1 style="margin-block-start: 0; font-size: 16px; font-weight: lighter">
+			<h1 style="margin-block-start: 0; font-size: 16px; font-weight: normal">
 				PlayerDB is a JSON powered player fetching and caching API service.
 			</h1>
 		</header>
@@ -230,11 +234,6 @@
 				/></a>
 			</p>
 		</footer>
-		<link
-			href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,400,300,600,700&display=optional"
-			rel="stylesheet"
-			type="text/css"
-		/>
 		<script
 			defer
 			data-domain="playerdb.co"


### PR DESCRIPTION
Fixes the weird font rendering issue I was having on the site a few days ago. Turns out Linux was displaying it correctly. We were essentially requiring the font to respond in 100ms or it'd fallback to system fonts. On Windows this produced a correct enough look that we never noticed. Once I swapped to Linux it was falling back to a more accurate look to what we had. 

This PR just forces it to just swap in the font whenever it loads, that way it looks correct for all OSes. 

Old:
<img width="646" height="1344" alt="image" src="https://github.com/user-attachments/assets/42b9435e-ed67-411d-b283-973471040bbc" />


New:
<img width="567" height="839" alt="image" src="https://github.com/user-attachments/assets/8d6ba755-c06c-4566-9b4f-80f7386d8cd6" />
